### PR TITLE
Added GPU usage per user and per account

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -26,7 +26,7 @@ import (
 )
 
 func AccountsData() []byte {
-        cmd := exec.Command("squeue","-a","-r","-h","-o %A|%a|%T|%C")
+        cmd := exec.Command("squeue","-a","-r","-h","-o %A|%a|%T|%C|%b")
         stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)
@@ -44,8 +44,10 @@ func AccountsData() []byte {
 type JobMetrics struct {
         pending float64
         pending_cpus float64
+        pending_gpus float64
         running float64
         running_cpus float64
+        running_gpus float64
         suspended float64
 }
 
@@ -57,11 +59,17 @@ func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
                         account := strings.Split(line,"|")[1]
                         _,key := accounts[account]
                         if !key {
-                                accounts[account] = &JobMetrics{0,0,0,0,0}
+                                accounts[account] = &JobMetrics{0,0,0,0,0,0,0}
                         }
                         state := strings.Split(line,"|")[2]
                         state = strings.ToLower(state)
                         cpus,_ := strconv.ParseFloat(strings.Split(line,"|")[3],64)
+                        gres := strings.Split(line, "|")[4]
+                        var gpus float64 = 0
+                        if gres != "N/A" {
+                                gpus, _ = strconv.ParseFloat(gres[9:], 64)
+                        }
+
                         pending := regexp.MustCompile(`^pending`)
                         running := regexp.MustCompile(`^running`)
                         suspended := regexp.MustCompile(`^suspended`)
@@ -69,9 +77,11 @@ func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
                         case pending.MatchString(state) == true:
                                 accounts[account].pending++
                                 accounts[account].pending_cpus += cpus
+                                accounts[account].pending_gpus += gpus
                         case running.MatchString(state) == true:
                                 accounts[account].running++
                                 accounts[account].running_cpus += cpus
+                                accounts[account].running_gpus += gpus
                         case suspended.MatchString(state) == true:
                                 accounts[account].suspended++
                         }
@@ -83,18 +93,22 @@ func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
 type AccountsCollector struct {
         pending *prometheus.Desc
         pending_cpus *prometheus.Desc
+        pending_gpus *prometheus.Desc
         running *prometheus.Desc
         running_cpus *prometheus.Desc
+        running_gpus *prometheus.Desc
         suspended *prometheus.Desc
 }
 
 func NewAccountsCollector() *AccountsCollector {
         labels := []string{"account"}
         return &AccountsCollector{
-                pending: prometheus.NewDesc("slurm_account_jobs_pending", "Pending jobs for account", labels, nil),
-                pending_cpus: prometheus.NewDesc("slurm_account_cpus_pending", "Pending jobs for account", labels, nil),
+                pending: prometheus.NewDesc("slurm_account_jobs_pending", "Pending jobs for account", labels, nil), 
+                pending_cpus: prometheus.NewDesc("slurm_account_cpus_pending", "Pending cpus for account", labels, nil), 
+                pending_gpus: prometheus.NewDesc("slurm_account_gpus_pending", "Pending gpus for account", labels, nil), 
                 running: prometheus.NewDesc("slurm_account_jobs_running", "Running jobs for account", labels, nil),
                 running_cpus: prometheus.NewDesc("slurm_account_cpus_running", "Running cpus for account", labels, nil),
+                running_gpus: prometheus.NewDesc("slurm_account_gpus_running", "Running gpus for account", labels, nil),
                 suspended: prometheus.NewDesc("slurm_account_jobs_suspended", "Suspended jobs for account", labels, nil),
         }
 }
@@ -102,8 +116,10 @@ func NewAccountsCollector() *AccountsCollector {
 func (ac *AccountsCollector) Describe(ch chan<- *prometheus.Desc) {
         ch <- ac.pending
         ch <- ac.pending_cpus
+        ch <- ac.pending_gpus
         ch <- ac.running
         ch <- ac.running_cpus
+        ch <- ac.running_gpus
         ch <- ac.suspended
 }
 
@@ -116,11 +132,17 @@ func (ac *AccountsCollector) Collect(ch chan<- prometheus.Metric) {
                 if am[a].pending_cpus > 0 {
                         ch <- prometheus.MustNewConstMetric(ac.pending_cpus, prometheus.GaugeValue, am[a].pending_cpus, a)
                 }
+                if am[a].pending_gpus > 0 {
+                        ch <- prometheus.MustNewConstMetric(ac.pending_gpus, prometheus.GaugeValue, am[a].pending_gpus, a)
+                }
                 if am[a].running > 0 {
                         ch <- prometheus.MustNewConstMetric(ac.running, prometheus.GaugeValue, am[a].running, a)
                 }
                 if am[a].running_cpus > 0 {
                         ch <- prometheus.MustNewConstMetric(ac.running_cpus, prometheus.GaugeValue, am[a].running_cpus, a)
+                }
+                if am[a].running_gpus > 0 {
+                        ch <- prometheus.MustNewConstMetric(ac.running_gpus, prometheus.GaugeValue, am[a].running_gpus, a)
                 }
                 if am[a].suspended > 0 {
                         ch <- prometheus.MustNewConstMetric(ac.suspended, prometheus.GaugeValue, am[a].suspended, a)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/itzsimpl/prometheus-slurm-exporter
+module github.com/vpenso/prometheus-slurm-exporter
 
 go 1.12
 

--- a/users.go
+++ b/users.go
@@ -26,7 +26,7 @@ import (
 )
 
 func UsersData() []byte {
-        cmd := exec.Command("squeue","-a","-r","-h","-o %A|%u|%T|%C")
+        cmd := exec.Command("squeue","-a","-r","-h","-o %A|%u|%T|%C|%b")
         stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)
@@ -44,9 +44,12 @@ func UsersData() []byte {
 type UserJobMetrics struct {
         pending float64
         pending_cpus float64
+        pending_gpus float64
         running float64
         running_cpus float64
+        running_gpus float64
         suspended float64
+        
 }
 
 func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
@@ -57,11 +60,17 @@ func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
                         user := strings.Split(line,"|")[1]
                         _,key := users[user]
                         if !key {
-                                users[user] = &UserJobMetrics{0,0,0,0,0}
+                                users[user] = &UserJobMetrics{0,0,0,0,0,0,0}
                         }
                         state := strings.Split(line,"|")[2]
                         state = strings.ToLower(state)
                         cpus,_ := strconv.ParseFloat(strings.Split(line,"|")[3],64)
+                        gres := strings.Split(line, "|")[4]
+                        var gpus float64 = 0
+                        if gres != "N/A" {
+                                gpus, _ = strconv.ParseFloat(gres[9:], 64)
+                        }
+                        
                         pending := regexp.MustCompile(`^pending`)
                         running := regexp.MustCompile(`^running`)
                         suspended := regexp.MustCompile(`^suspended`)
@@ -69,9 +78,11 @@ func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
                         case pending.MatchString(state) == true:
                                 users[user].pending++
                                 users[user].pending_cpus += cpus
+                                users[user].pending_gpus += gpus
                         case running.MatchString(state) == true:
                                 users[user].running++
                                 users[user].running_cpus += cpus
+                                users[user].running_gpus += gpus
                         case suspended.MatchString(state) == true:
                                 users[user].suspended++
                         }
@@ -83,8 +94,10 @@ func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
 type UsersCollector struct {
         pending *prometheus.Desc
         pending_cpus *prometheus.Desc
+        pending_gpus *prometheus.Desc
         running *prometheus.Desc
         running_cpus *prometheus.Desc
+        running_gpus *prometheus.Desc
         suspended *prometheus.Desc
 }
 
@@ -92,9 +105,11 @@ func NewUsersCollector() *UsersCollector {
         labels := []string{"user"}
         return &UsersCollector {
                 pending: prometheus.NewDesc("slurm_user_jobs_pending", "Pending jobs for user", labels, nil), 
-                pending_cpus: prometheus.NewDesc("slurm_user_cpus_pending", "Pending jobs for user", labels, nil), 
+                pending_cpus: prometheus.NewDesc("slurm_user_cpus_pending", "Pending cpus for user", labels, nil), 
+                pending_gpus: prometheus.NewDesc("slurm_user_gpus_pending", "Pending gpus for user", labels, nil), 
                 running: prometheus.NewDesc("slurm_user_jobs_running", "Running jobs for user", labels, nil),
                 running_cpus: prometheus.NewDesc("slurm_user_cpus_running", "Running cpus for user", labels, nil),
+                running_gpus: prometheus.NewDesc("slurm_user_gpus_running", "Running gpus for user", labels, nil),
                 suspended: prometheus.NewDesc("slurm_user_jobs_suspended", "Suspended jobs for user", labels, nil),
         }
 }
@@ -102,8 +117,10 @@ func NewUsersCollector() *UsersCollector {
 func (uc *UsersCollector) Describe(ch chan<- *prometheus.Desc) {
         ch <- uc.pending
         ch <- uc.pending_cpus
+        ch <- uc.pending_gpus
         ch <- uc.running
         ch <- uc.running_cpus
+        ch <- uc.running_gpus
         ch <- uc.suspended
 }
 
@@ -116,11 +133,17 @@ func (uc *UsersCollector) Collect(ch chan<- prometheus.Metric) {
                 if um[u].pending_cpus > 0 {
                         ch <- prometheus.MustNewConstMetric(uc.pending_cpus, prometheus.GaugeValue, um[u].pending_cpus, u)
                 }
+                if um[u].pending_gpus > 0 {
+                        ch <- prometheus.MustNewConstMetric(uc.pending_gpus, prometheus.GaugeValue, um[u].pending_gpus, u)
+                }
                 if um[u].running > 0 {
                         ch <- prometheus.MustNewConstMetric(uc.running, prometheus.GaugeValue, um[u].running, u)
                 }
                 if um[u].running_cpus > 0 {
                         ch <- prometheus.MustNewConstMetric(uc.running_cpus, prometheus.GaugeValue, um[u].running_cpus, u)
+                }
+                if um[u].running_gpus > 0 {
+                        ch <- prometheus.MustNewConstMetric(uc.running_gpus, prometheus.GaugeValue, um[u].running_gpus, u)
                 }
                 if um[u].suspended > 0 {
                         ch <- prometheus.MustNewConstMetric(uc.suspended, prometheus.GaugeValue, um[u].suspended, u)


### PR DESCRIPTION
Issue: https://github.com/centerforaisafety/prometheus-slurm-exporter/issues/1

Added GPU utilization per user and per account. Uses the exact same format as cpu with different names. If we change how accounting works for GPU we may have to adjust this as it does string matching in the output of squeue.