### PR TITLE
Allow parsing gres/gpu where there can be also gpu type in the string.

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -67,7 +67,11 @@ func ParseAccountsMetrics(input []byte) map[string]*JobMetrics {
                         gres := strings.Split(line, "|")[4]
                         var gpus float64 = 0
                         if gres != "N/A" {
-                                gpus, _ = strconv.ParseFloat(gres[9:], 64)
+                                //gpus, _ = strconv.ParseFloat(gres[9:], 64)
+				//gres can be of the format gres/gpu:a100:4 in our case
+				colonPosition := strings.LastIndex(gres, ":")
+				numGpu := strings.TrimSpace(gres[colonPosition+1:])
+				gpus, _ = strconv.ParseFloat(numGpu, 64)
                         }
 
                         pending := regexp.MustCompile(`^pending`)

--- a/users.go
+++ b/users.go
@@ -68,9 +68,11 @@ func ParseUsersMetrics(input []byte) map[string]*UserJobMetrics {
                         gres := strings.Split(line, "|")[4]
                         var gpus float64 = 0
                         if gres != "N/A" {
-                                gpus, _ = strconv.ParseFloat(gres[9:], 64)
+                                //gres can be of the format gres/gpu:a100:4 in our case
+                                colonPosition := strings.LastIndex(gres, ":")
+                                numGpu := strings.TrimSpace(gres[colonPosition+1:])
+                                gpus, _ = strconv.ParseFloat(numGpu, 64)
                         }
-                        
                         pending := regexp.MustCompile(`^pending`)
                         running := regexp.MustCompile(`^running`)
                         suspended := regexp.MustCompile(`^suspended`)


### PR DESCRIPTION
Allow more versatile gres string like "gres/gpu:a100:4". Simply use the number after final double colon instead of fixed char position.